### PR TITLE
Add make_tiny_files utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,22 @@ Cumulative awards for key biomedical topics.
 ## Working with cache files
 Large cache files necessary for plot generation are stored using Git LFS. To speed up cloning, use `git clone --filter=blob:none`. After cloning, run `git lfs pull` to fetch the cached data when needed.
 
+## Testing Data
+
+For development and continuous integration it can be useful to work with very
+small copies of the processed datasets. The `make_tiny_files.py` utility creates
+these truncated files by keeping only the header and the first *N* data rows of a
+CSV (plain or `.csv.zst`).
+
+Example:
+
+```bash
+python utils/data-processors/make_tiny_files.py \
+    --input data/processed/taggs/hhs_grants_terminated.csv \
+    --output data/tiny/hhs_grants_terminated.csv \
+    --lines 10
+```
+
+The script automatically handles both plain CSV files and zstd-compressed CSV
+files (`.csv.zst`).
+

--- a/utils/data-processors/make_tiny_files.py
+++ b/utils/data-processors/make_tiny_files.py
@@ -1,0 +1,53 @@
+import argparse
+import io
+from pathlib import Path
+import zstandard as zstd
+
+
+def truncate_csv(input_path: Path, output_path: Path, lines: int) -> None:
+    """Copy header and first N rows from a plain CSV file."""
+    with input_path.open('r', encoding='utf-8') as f_in, \
+            output_path.open('w', encoding='utf-8') as f_out:
+        for i, line in enumerate(f_in):
+            f_out.write(line)
+            if i >= lines:
+                break
+
+
+def truncate_csv_zst(input_path: Path, output_path: Path, lines: int) -> None:
+    """Decompress .csv.zst, truncate to N rows, recompress."""
+    dctx = zstd.ZstdDecompressor()
+    with input_path.open('rb') as f_in, dctx.stream_reader(f_in) as reader:
+        text_reader = io.TextIOWrapper(reader, encoding='utf-8')
+        lines_buf = []
+        for i, line in enumerate(text_reader):
+            lines_buf.append(line)
+            if i >= lines:
+                break
+    cctx = zstd.ZstdCompressor()
+    with output_path.open('wb') as f_out, cctx.stream_writer(f_out) as writer:
+        for line in lines_buf:
+            writer.write(line.encode('utf-8'))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create small test files by keeping only the first N rows of a CSV or CSV.ZST"
+    )
+    parser.add_argument('--input', required=True, help='Input CSV or CSV.ZST file')
+    parser.add_argument('--output', required=True, help='Destination path for the tiny file')
+    parser.add_argument('--lines', type=int, required=True, help='Number of data lines to keep')
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if input_path.suffix == '.zst' or input_path.name.endswith('.csv.zst'):
+        truncate_csv_zst(input_path, output_path, args.lines)
+    else:
+        truncate_csv(input_path, output_path, args.lines)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a helper script to create small CSV/CSV.ZST files
- document how to generate test data

## Testing
- `python -m py_compile utils/data-processors/make_tiny_files.py`
- `python utils/data-processors/make_tiny_files.py --input data/processed/taggs/hhs_grants_terminated.csv --output data/tiny/hhs_grants_terminated.csv --lines 2` *(fails: No module named 'zstandard')*

------
https://chatgpt.com/codex/tasks/task_b_683d9c58be04832a9fd26de70b70c1b4