### PR TITLE
Add make_tiny_files utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,22 @@ Cumulative awards for key biomedical topics.
 ## Working with cache files
 Large cache files necessary for plot generation are stored using Git LFS. To speed up cloning, use `git clone --filter=blob:none`. After cloning, run `git lfs pull` to fetch the cached data when needed.
 
+## Testing Data
+
+For development and continuous integration it can be useful to work with very
+small copies of the processed datasets and caches. The `make_tiny_files.py`
+utility creates these truncated files by keeping only the first *N* elements of a
+CSV or JSON file. Compressed variants ending in `.zst` are also supported.
+
+Example:
+
+```bash
+python utils/data-processors/make_tiny_files.py \
+    --input data/processed/taggs/hhs_grants_terminated.csv \
+    --output data/tiny/hhs_grants_terminated.csv \
+    --lines 10
+```
+
+The script automatically handles plain CSV/JSON files as well as their
+zstd-compressed counterparts (`.csv.zst` / `.json.zst`).
+

--- a/utils/data-processors/make_tiny_files.py
+++ b/utils/data-processors/make_tiny_files.py
@@ -1,0 +1,93 @@
+import argparse
+import io
+import json
+from pathlib import Path
+import zstandard as zstd
+
+
+def truncate_csv(input_path: Path, output_path: Path, lines: int) -> None:
+    """Copy header and first N rows from a plain CSV file."""
+    with input_path.open("r", encoding="utf-8") as f_in, \
+        output_path.open("w", encoding="utf-8") as f_out:
+        for i, line in enumerate(f_in):
+            f_out.write(line)
+            if i >= lines:
+                break
+
+
+def truncate_csv_zst(input_path: Path, output_path: Path, lines: int) -> None:
+    """Decompress .csv.zst, truncate to N rows, recompress."""
+    dctx = zstd.ZstdDecompressor()
+    with input_path.open("rb") as f_in, dctx.stream_reader(f_in) as reader:
+        text_reader = io.TextIOWrapper(reader, encoding="utf-8")
+        lines_buf = []
+        for i, line in enumerate(text_reader):
+            lines_buf.append(line)
+            if i >= lines:
+                break
+    cctx = zstd.ZstdCompressor()
+    with output_path.open("wb") as f_out, cctx.stream_writer(f_out) as writer:
+        for line in lines_buf:
+            writer.write(line.encode("utf-8"))
+
+
+def truncate_json(input_path: Path, output_path: Path, lines: int) -> None:
+    """Truncate a JSON array to the first N elements."""
+    with input_path.open("r", encoding="utf-8") as f_in:
+        data = json.load(f_in)
+    if isinstance(data, list):
+        data = data[:lines]
+    with output_path.open("w", encoding="utf-8") as f_out:
+        json.dump(data, f_out)
+
+
+def truncate_json_zst(input_path: Path, output_path: Path, lines: int) -> None:
+    """Decompress .json.zst, truncate to N elements if array, recompress."""
+    dctx = zstd.ZstdDecompressor()
+    with input_path.open("rb") as f_in, dctx.stream_reader(f_in) as reader:
+        text_reader = io.TextIOWrapper(reader, encoding="utf-8")
+        data = json.load(text_reader)
+    if isinstance(data, list):
+        data = data[:lines]
+    cctx = zstd.ZstdCompressor()
+    with output_path.open("wb") as f_out, cctx.stream_writer(f_out) as writer:
+        with io.TextIOWrapper(writer, encoding="utf-8") as text_writer:
+            json.dump(data, text_writer)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create small test files by keeping only the first N rows of a CSV/JSON"
+            " file. Compressed .zst variants are supported."
+        )
+    )
+    parser.add_argument('--input', required=True, help='Input CSV/JSON file')
+    parser.add_argument('--output', required=True, help='Destination path for the tiny file')
+    parser.add_argument('--lines', type=int, required=True, help='Number of data lines/elements to keep')
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    suffix = input_path.suffix
+    name = input_path.name
+    if suffix == '.zst':
+        if name.endswith('.csv.zst'):
+            truncate_csv_zst(input_path, output_path, args.lines)
+        elif name.endswith('.json.zst'):
+            truncate_json_zst(input_path, output_path, args.lines)
+        else:
+            raise ValueError(f'Unknown compressed file type: {input_path}')
+    else:
+        if suffix == '.csv':
+            truncate_csv(input_path, output_path, args.lines)
+        elif suffix == '.json':
+            truncate_json(input_path, output_path, args.lines)
+        else:
+            raise ValueError(f'Unsupported file extension: {input_path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a helper script to create small CSV/CSV.ZST files
- document how to generate test data
- extend utility to also handle JSON/JSON.ZST files

## Testing
- `python -m py_compile utils/data-processors/make_tiny_files.py`
- `python utils/data-processors/make_tiny_files.py --input data/processed/taggs/hhs_grants_terminated.csv --output data/tiny/hhs_grants_terminated.csv --lines 2` *(fails: No module named 'zstandard')*


------
https://chatgpt.com/codex/tasks/task_b_683d9c58be04832a9fd26de70b70c1b4