### PR TITLE
Disable automatic trigger for update workflow

### DIFF
--- a/.github/workflows/update-nih-data.yml
+++ b/.github/workflows/update-nih-data.yml
@@ -1,8 +1,5 @@
 name: Update NIH Reporter Data
 on:
-  push:
-    branches:
-      - main
   schedule:
     - cron: '0 12 * * *' # Run at noon every day
   workflow_dispatch:    # Allow manual triggers


### PR DESCRIPTION
## Summary
- remove the `push` trigger from `update-nih-data.yml` so the workflow doesn't run on each commit

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_683d9787d1dc832a9e76b827f8074fdf